### PR TITLE
Fixed repository link in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/sylvainpolletvillard/baragouin.git"
+    "url": "https://github.com/sylvainpolletvillard/baragouin.git"
   },
   "keywords": [
     "audio",


### PR DESCRIPTION
I noticed the Git repository does not show up on the NPM page!
This is because the protocol part is missing in the given URL.

I fixed this!